### PR TITLE
Removed proposal doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 
 # ML-Agents DOTS
 
-[ML-Agents on DOTS Proposal Google Doc](https://docs.google.com/document/d/1QnGSjOfLpwaRopbMf9ZDC89oZJuG0Ii6ORA22a5TWzE/edit#heading=h.py1zfmz3396x)
-
 [Documentation](./Documentation~/README.md)
 


### PR DESCRIPTION
Not sure if this is needed since external folks will access.  If so, feel free to reject the suggestion.  Should probably make the doc publicly accessible with the link.